### PR TITLE
Improve Rust idiomatic practices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "tiktoklive"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "bytes",
  "env_logger",

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,6 @@
-pub mod live_client_builder;
 pub mod live_client;
+pub mod live_client_builder;
 pub mod live_client_events;
 pub mod live_client_http;
-pub mod live_client_websocket;
 pub mod live_client_mapper;
-
+pub mod live_client_websocket;

--- a/src/core/live_client_builder.rs
+++ b/src/core/live_client_builder.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 
@@ -10,33 +8,25 @@ use crate::core::live_client_mapper::TikTokLiveMessageMapper;
 use crate::core::live_client_websocket::TikTokLiveWebsocketClient;
 use crate::data::create_default_settings;
 use crate::data::live_common::{TikTokLiveInfo, TikTokLiveSettings};
-use crate::generated::events::TikTokLiveEvent;
 use crate::http::http_request_builder::HttpRequestFactory;
 
-
-
-pub struct TikTokLiveBuilder
-{
+pub struct TikTokLiveBuilder {
     settings: TikTokLiveSettings,
     pub(crate) event_observer: TikTokLiveEventObserver,
 }
 
-impl TikTokLiveBuilder
-{
+impl TikTokLiveBuilder {
     ///
     ///  # Create new tiktok live builder
     ///
     ///  ### user_name - name of tiktok user that can be found in the live link
     ///
-    pub fn new(user_name: &str) -> Self
-    {
-        let env = Env::default()
-            .filter_or("MY_LOG_LEVEL", "info");
+    pub fn new(user_name: &str) -> Self {
+        let env = Env::default().filter_or("MY_LOG_LEVEL", "info");
         Builder::from_env(env)
             .filter_module("my_crate::module", LevelFilter::Debug)
             .init();
-        Self
-        {
+        Self {
             settings: create_default_settings(user_name),
             event_observer: TikTokLiveEventObserver::new(),
         }
@@ -47,7 +37,8 @@ impl TikTokLiveBuilder
     ///
     ///
     pub fn configure<F>(&mut self, on_configure: F) -> &mut Self
-        where F: FnOnce(&mut TikTokLiveSettings),
+    where
+        F: FnOnce(&mut TikTokLiveSettings),
     {
         on_configure(&mut self.settings);
         self
@@ -60,12 +51,10 @@ impl TikTokLiveBuilder
     ///    ## event  - invoked event
     ///  ```
     ///
-    pub fn on_event(&mut self, on_event: TikTokEventHandler) -> &mut Self
-    {
+    pub fn on_event(&mut self, on_event: TikTokEventHandler) -> &mut Self {
         self.event_observer.subscribe(on_event);
         self
     }
-
 
     ///
     /// Returns new instance of TikTokLiveClient
@@ -73,24 +62,22 @@ impl TikTokLiveBuilder
     pub fn build(&self) -> TikTokLiveClient {
         let settings = &self.settings;
         let observer = self.event_observer.clone();
-        let mapper = TikTokLiveMessageMapper
-        {};
+        let mapper = TikTokLiveMessageMapper {};
         let websocket_client = TikTokLiveWebsocketClient::new(mapper);
         let http_factory = HttpRequestFactory {
-            settings: settings.clone()
+            settings: settings.clone(),
         };
-        let http_client = TikTokLiveHttpClient
-        {
+        let http_client = TikTokLiveHttpClient {
             settings: settings.clone(),
             factory: http_factory,
         };
 
-        return TikTokLiveClient::new(
+        TikTokLiveClient::new(
             settings.clone(),
             http_client,
             observer,
             websocket_client,
             TikTokLiveInfo::default(),
-        );
+        )
     }
 }

--- a/src/core/live_client_events.rs
+++ b/src/core/live_client_events.rs
@@ -4,30 +4,21 @@ use crate::generated::events::TikTokLiveEvent;
 pub type TikTokEventHandler = fn(client: &TikTokLiveClient, event: &TikTokLiveEvent);
 
 #[derive(Clone)]
-pub struct TikTokLiveEventObserver
-{
+pub struct TikTokLiveEventObserver {
     pub events: Vec<TikTokEventHandler>,
 }
 
-impl TikTokLiveEventObserver
-{
-    pub fn new() -> Self
-    {
-        TikTokLiveEventObserver
-        {
-            events: vec![]
-        }
+impl TikTokLiveEventObserver {
+    pub fn new() -> Self {
+        TikTokLiveEventObserver { events: vec![] }
     }
 
-    pub fn subscribe(&mut self, handler: TikTokEventHandler)
-    {
+    pub fn subscribe(&mut self, handler: TikTokEventHandler) {
         self.events.push(handler);
     }
 
-    pub fn publish(&self, client: &TikTokLiveClient, event: TikTokLiveEvent)
-    {
-        for handler in &self.events
-        {
+    pub fn publish(&self, client: &TikTokLiveClient, event: TikTokLiveEvent) {
+        for handler in &self.events {
             handler(client, &event);
         }
     }

--- a/src/core/live_client_http.rs
+++ b/src/core/live_client_http.rs
@@ -1,13 +1,17 @@
 use protobuf::Message;
 
 use crate::data::live_common::TikTokLiveSettings;
-use crate::http::http_data::{LiveConnectionDataRequest, LiveConnectionDataResponse, LiveDataRequest, LiveDataResponse, LiveUserDataRequest, LiveUserDataResponse};
-use crate::http::http_data_mappers::{map_live_data_response, map_live_user_data_response, map_sign_server_response};
-use crate::http::http_request_builder::HttpRequestFactory;
 use crate::generated::messages::webcast::WebcastResponse;
+use crate::http::http_data::{
+    LiveConnectionDataRequest, LiveConnectionDataResponse, LiveDataRequest, LiveDataResponse,
+    LiveUserDataRequest, LiveUserDataResponse,
+};
+use crate::http::http_data_mappers::{
+    map_live_data_response, map_live_user_data_response, map_sign_server_response,
+};
+use crate::http::http_request_builder::HttpRequestFactory;
 
-pub struct TikTokLiveHttpClient
-{
+pub struct TikTokLiveHttpClient {
     pub(crate) settings: TikTokLiveSettings,
     pub(crate) factory: HttpRequestFactory,
 }
@@ -16,17 +20,11 @@ pub const TIKTOK_URL_WEB: &str = "https://www.tiktok.com/";
 pub const TIKTOK_URL_WEBCAST: &str = "https://webcast.tiktok.com/webcast/";
 pub const TIKTOK_SIGN_API: &str = "https://tiktok.eulerstream.com/webcast/sign_url";
 
-
-
-
-impl TikTokLiveHttpClient
-{
-
-
-    pub async fn fetch_live_user_data(&self, request: LiveUserDataRequest) -> LiveUserDataResponse
-    {
+impl TikTokLiveHttpClient {
+    pub async fn fetch_live_user_data(&self, request: LiveUserDataRequest) -> LiveUserDataResponse {
         let url = format!("{}{}", TIKTOK_URL_WEB, "api-live/user/room");
-        let option = self.factory
+        let option = self
+            .factory
             .request()
             .with_url(url.as_str())
             .with_param("uniqueId", request.user_name.as_str())
@@ -34,43 +32,44 @@ impl TikTokLiveHttpClient
             .as_json()
             .await;
 
-        if option.is_none()
-        {
+        if option.is_none() {
             panic!("Unable to get info about user ")
         }
         let json = option.unwrap();
         return map_live_user_data_response(json);
     }
-    pub async fn fetch_live_data(&self, request: LiveDataRequest) -> LiveDataResponse
-    {
+    pub async fn fetch_live_data(&self, request: LiveDataRequest) -> LiveDataResponse {
         let url = format!("{}{}", TIKTOK_URL_WEBCAST, "room/info");
-        let option = self.factory
+        let option = self
+            .factory
             .request()
             .with_url(url.as_str())
             .with_param("room_id", request.room_id.as_str())
             .as_json()
             .await;
 
-
-        if option.is_none()
-        {
+        if option.is_none() {
             panic!("Unable to get info about live room")
         }
         let json = option.unwrap();
         return map_live_data_response(json);
     }
 
-    pub async fn fetch_live_connection_data(&self, request: LiveConnectionDataRequest) -> LiveConnectionDataResponse
-    {
+    pub async fn fetch_live_connection_data(
+        &self,
+        request: LiveConnectionDataRequest,
+    ) -> LiveConnectionDataResponse {
         //Preparing URL to sign
-        let url_to_sign = self.factory
+        let url_to_sign = self
+            .factory
             .request()
             .with_url(format!("{}{}", TIKTOK_URL_WEBCAST, "im/fetch").as_str())
             .with_param("room_id", request.room_id.as_str())
             .as_url();
 
         //Signing URL
-        let option = self.factory
+        let option = self
+            .factory
             .request()
             .with_url(TIKTOK_SIGN_API)
             .with_param("client", "ttlive-rust")
@@ -79,15 +78,15 @@ impl TikTokLiveHttpClient
             .as_json()
             .await;
 
-        if option.is_none()
-        {
+        if option.is_none() {
             panic!("Unable sign url {}", url_to_sign.as_str())
         }
         let json = option.unwrap();
         let sign_server_response = map_sign_server_response(json);
 
         //Getting credentials for connection to websocket
-        let response = self.factory
+        let response = self
+            .factory
             .request()
             .with_reset()
             .with_time_out(self.settings.http_data.time_out)
@@ -97,23 +96,20 @@ impl TikTokLiveHttpClient
             .await
             .unwrap();
 
-
         let optional_header = response.headers().get("set-cookie");
 
-        if optional_header.is_none()
-        {
+        if optional_header.is_none() {
             panic!("Header was not received not provided")
         }
         let header_value = optional_header.unwrap().to_str().unwrap().to_string();
-
 
         let protocol_buffer_message = response.bytes().await.unwrap();
         let webcast_response = WebcastResponse::parse_from_bytes(protocol_buffer_message.as_ref())
             .expect("Unable to parse bytes to Push Frame!");
 
-
         //preparing websocket url
-        let web_socket_url = self.factory
+        let web_socket_url = self
+            .factory
             .request()
             .with_url(webcast_response.pushServer.as_str())
             .with_param("room_id", request.room_id.as_str())
@@ -125,8 +121,7 @@ impl TikTokLiveHttpClient
 
         let url = url::Url::parse(web_socket_url.as_str()).unwrap();
 
-        return LiveConnectionDataResponse
-        {
+        return LiveConnectionDataResponse {
             web_socket_timeout: self.settings.http_data.time_out,
             web_socket_cookies: header_value,
             web_socket_url: url,

--- a/src/core/live_client_mapper.rs
+++ b/src/core/live_client_mapper.rs
@@ -1,29 +1,27 @@
 use crate::core::live_client::TikTokLiveClient;
 use crate::generated::events::{TikTokLiveEvent, TikTokWebsocketResponseEvent};
-use crate::generated::messages::webcast::{file_descriptor, WebcastGiftMessage, WebcastMemberMessage, WebcastResponse};
+use crate::generated::messages::webcast::WebcastResponse;
 
 #[derive(Clone)]
-pub struct TikTokLiveMessageMapper
-{}
+pub struct TikTokLiveMessageMapper {}
 
-impl TikTokLiveMessageMapper
-{
-    pub fn handle_webcast_response(&self, webcast_response: WebcastResponse, client: &TikTokLiveClient)
-    {
-        client.publish_event(TikTokLiveEvent::OnWebsocketResponse(TikTokWebsocketResponseEvent
-        {
-            raw_data: webcast_response.clone(),
-        }));
-        for message in &webcast_response.messages
-        {
+impl TikTokLiveMessageMapper {
+    pub fn handle_webcast_response(
+        &self,
+        webcast_response: WebcastResponse,
+        client: &TikTokLiveClient,
+    ) {
+        client.publish_event(TikTokLiveEvent::OnWebsocketResponse(
+            TikTokWebsocketResponseEvent {
+                raw_data: webcast_response.clone(),
+            },
+        ));
+        for message in &webcast_response.messages {
             self.handle_single_message(message.clone(), client);
         }
     }
 
-    pub fn dupa(&self,webcast_response: WebcastResponse,client: &TikTokLiveClient)
-    {
-
+    pub fn dupa(&self, _webcast_response: WebcastResponse, _client: &TikTokLiveClient) {
         println!("XD")
     }
 }
-

--- a/src/core/live_client_websocket.rs
+++ b/src/core/live_client_websocket.rs
@@ -1,9 +1,7 @@
-use std::ops::Deref;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
 use protobuf::Message;
-use tokio::runtime::Runtime;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
 use tokio_tungstenite::tungstenite::connect;
 use tokio_tungstenite::tungstenite::handshake::client::Request;
 
@@ -11,18 +9,15 @@ use crate::core::live_client::TikTokLiveClient;
 use crate::core::live_client_mapper::TikTokLiveMessageMapper;
 use crate::data::live_common::ConnectionState::CONNECTED;
 use crate::generated::events::{TikTokConnectedEvent, TikTokLiveEvent};
-use crate::http::http_data::LiveConnectionDataResponse;
 use crate::generated::messages::webcast::{WebcastPushFrame, WebcastResponse};
+use crate::http::http_data::LiveConnectionDataResponse;
 
-
-pub struct TikTokLiveWebsocketClient
-{
+pub struct TikTokLiveWebsocketClient {
     pub(crate) message_mapper: TikTokLiveMessageMapper,
     pub(crate) running: Arc<AtomicBool>,
 }
 
-impl TikTokLiveWebsocketClient
-{
+impl TikTokLiveWebsocketClient {
     pub fn new(message_mapper: TikTokLiveMessageMapper) -> Self {
         TikTokLiveWebsocketClient {
             message_mapper,
@@ -30,12 +25,13 @@ impl TikTokLiveWebsocketClient
         }
     }
 
+    pub async fn start(&self, response: LiveConnectionDataResponse, client: Arc<TikTokLiveClient>) {
+        let host = response
+            .web_socket_url
+            .host_str()
+            .expect("Invalid host in WebSocket URL");
 
-    pub async fn start(&self, response: LiveConnectionDataResponse,  client: Arc<TikTokLiveClient>)
-    {
-        let host = response.web_socket_url.host_str().expect("Invalid host in WebSocket URL");
-
-          let request = Request::builder()
+        let request = Request::builder()
             .method("GET")
             .uri(response.web_socket_url.to_string())
             .header("Host", host)
@@ -53,12 +49,11 @@ impl TikTokLiveWebsocketClient
             .header("Sec-Websocket-Version", "13")
             .body(())
             .unwrap();
-        
+
         let (mut socket, _) = connect(request).expect("Failed to connect");
 
         client.set_connection_state(CONNECTED);
         client.publish_event(TikTokLiveEvent::OnConnected(TikTokConnectedEvent {}));
-
 
         let running = self.running.clone();
         running.store(true, Ordering::SeqCst);
@@ -66,23 +61,23 @@ impl TikTokLiveWebsocketClient
         let message_mapper = self.message_mapper.clone();
 
         thread::spawn(move || {
-            while running.load(Ordering::SeqCst)
-            {
+            while running.load(Ordering::SeqCst) {
                 let optional_message = socket.read_message();
 
-                if (optional_message.is_err())
-                {
+                if optional_message.is_err() {
                     continue;
                 }
                 let message = optional_message.unwrap();
 
                 let buffer = message.into_data();
 
-                let mut push_frame = WebcastPushFrame::parse_from_bytes(buffer.as_slice()).expect("Unable to read push frame");
-                let webcast_response = WebcastResponse::parse_from_bytes(push_frame.Payload.as_mut_slice()).expect("Unable to read webcast response");
+                let mut push_frame = WebcastPushFrame::parse_from_bytes(buffer.as_slice())
+                    .expect("Unable to read push frame");
+                let webcast_response =
+                    WebcastResponse::parse_from_bytes(push_frame.Payload.as_mut_slice())
+                        .expect("Unable to read webcast response");
 
-                if webcast_response.needsAck
-                {
+                if webcast_response.needsAck {
                     let mut push_frame_ack = WebcastPushFrame::new();
                     push_frame_ack.PayloadType = "ack".to_string();
                     push_frame_ack.LogId = push_frame.LogId;
@@ -90,7 +85,9 @@ impl TikTokLiveWebsocketClient
 
                     let binary = push_frame_ack.write_to_bytes().unwrap();
                     let message = tungstenite::protocol::Message::binary(binary);
-                    socket.write_message(message).expect("Unable to send ack packet");
+                    socket
+                        .write_message(message)
+                        .expect("Unable to send ack packet");
                 }
 
                 message_mapper.handle_webcast_response(webcast_response, client.as_ref());
@@ -98,8 +95,7 @@ impl TikTokLiveWebsocketClient
         });
     }
 
-    pub fn stop(&self)
-    {
+    pub fn stop(&self) {
         self.running.store(false, Ordering::SeqCst);
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,28 +5,22 @@ use crate::data::live_common::{HttpData, TikTokLiveSettings};
 
 pub mod live_common;
 
-
-pub fn create_default_settings(host_name: &str) -> TikTokLiveSettings
-{
-    return TikTokLiveSettings
-    {
+pub fn create_default_settings(host_name: &str) -> TikTokLiveSettings {
+    TikTokLiveSettings {
         language: "en-US".to_string(),
         print_logs: true,
         reconnect_on_fail: true,
         host_name: host_name.to_string(),
-        http_data: HttpData
-        {
+        http_data: HttpData {
             time_out: Duration::from_secs(3),
             cookies: create_default_cookies(),
             headers: create_default_headers(),
             params: create_default_params(),
         },
-    };
+    }
 }
 
-
-fn create_default_params()  -> HashMap<String,String>
-{
+fn create_default_params() -> HashMap<String, String> {
     let mut params: Vec<(&str, &str)> = Vec::new();
     params.push(("aid", "1988"));
     params.push(("app_language", "en-US"));
@@ -61,13 +55,13 @@ fn create_default_params()  -> HashMap<String,String>
     params.push(("webcast_sdk_version", "1.3.0"));
     params.push(("update_version_code", "1.3.0"));
 
-    return params.iter()
+    params
+        .iter()
         .map(|(key, value)| (key.to_string(), value.to_string()))
-        .collect();
+        .collect()
 }
 
-fn create_default_headers()  -> HashMap<String,String>
-{
+fn create_default_headers() -> HashMap<String, String> {
     let mut headers: Vec<(&str, &str)> = Vec::new();
 
     headers.push(("authority", "www.core.com"));
@@ -79,14 +73,12 @@ fn create_default_headers()  -> HashMap<String,String>
     headers.push(("Origin", "https://www.tiktok.com"));
     headers.push(("Accept-Language", "en-US,en; q=0.9"));
 
-
-    return headers.iter()
+    headers
+        .iter()
         .map(|(key, value)| (key.to_string(), value.to_string()))
-        .collect();
+        .collect()
 }
 
-
-fn create_default_cookies() -> HashMap<String,String>
-{
-    return HashMap::new();
+fn create_default_cookies() -> HashMap<String, String> {
+    HashMap::new()
 }

--- a/src/data/live_common.rs
+++ b/src/data/live_common.rs
@@ -1,11 +1,9 @@
-use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 
 #[derive(Clone)]
-pub struct TikTokLiveSettings
-{
+pub struct TikTokLiveSettings {
     pub host_name: String,
     pub language: String,
     pub reconnect_on_fail: bool,
@@ -13,11 +11,8 @@ pub struct TikTokLiveSettings
     pub http_data: HttpData,
 }
 
-
-#[derive(Clone)]
-#[derive(Default)]
-pub struct HttpData
-{
+#[derive(Clone, Default)]
+pub struct HttpData {
     pub time_out: Duration,
     pub params: HashMap<String, String>,
     pub headers: HashMap<String, String>,
@@ -25,8 +20,7 @@ pub struct HttpData
 }
 
 #[derive(Default)]
-pub struct TikTokLiveInfo
-{
+pub struct TikTokLiveInfo {
     pub room_id: String,
     pub likes: i32,
     pub viewers: i32,
@@ -38,14 +32,14 @@ pub struct TikTokLiveInfo
 }
 
 #[derive(PartialEq, Debug)]
-pub enum ConnectionState
-{
+pub enum ConnectionState {
     CONNECTING,
     CONNECTED,
     DISCONNECTED,
 }
 
-
 impl Default for ConnectionState {
-    fn default() -> Self { ConnectionState::DISCONNECTED }
+    fn default() -> Self {
+        ConnectionState::DISCONNECTED
+    }
 }

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1,3 +1,3 @@
-pub mod messages;
 pub mod events;
 pub mod events_mapper;
+pub mod messages;

--- a/src/generated/events.rs
+++ b/src/generated/events.rs
@@ -1,5 +1,5 @@
-use crate::generated::messages::webcast::*;
 use crate::generated::messages::webcast::webcast_response::Message;
+use crate::generated::messages::webcast::*;
 ///
 /// Generated file
 ///

--- a/src/generated/events_builder.rs
+++ b/src/generated/events_builder.rs
@@ -10,564 +10,462 @@ impl TikTokLiveBuilder {
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLikeEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLike(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLike(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_question_new(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokQuestionNewEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnQuestionNew(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnQuestionNew(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_mic_battle_punish_finish(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokLinkMicBattlePunishFinishEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkMicBattlePunishFinishEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkMicBattlePunishFinish(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkMicBattlePunishFinish(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_rank_update(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRankUpdateEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRankUpdate(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRankUpdate(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_mic_fan_ticket_method(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokLinkMicFanTicketMethodEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkMicFanTicketMethodEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkMicFanTicketMethod(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkMicFanTicketMethod(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_live_intro(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLiveIntroEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLiveIntro(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLiveIntro(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_member(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokMemberEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnMember(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnMember(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_chat(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokChatEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnChat(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnChat(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_mic_armies(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkMicArmiesEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkMicArmies(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkMicArmies(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_layer(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkLayerEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkLayer(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkLayer(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_websocket_response(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokWebsocketResponseEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokWebsocketResponseEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnWebsocketResponse(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnWebsocketResponse(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_response(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokResponseEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnResponse(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnResponse(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_push_frame(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokPushFrameEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnPushFrame(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnPushFrame(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_rank_text(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRankTextEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRankText(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRankText(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_system(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokSystemEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnSystem(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnSystem(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_linkmic_battle_task(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokLinkmicBattleTaskEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkmicBattleTaskEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkmicBattleTask(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkmicBattleTask(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_gift(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokGiftEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnGift(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnGift(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_in_room_banner(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokInRoomBannerEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnInRoomBanner(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnInRoomBanner(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_msg_detect(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokMsgDetectEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnMsgDetect(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnMsgDetect(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_control(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokControlEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnControl(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnControl(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_mic_method(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkMicMethodEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkMicMethod(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkMicMethod(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_goal_update(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokGoalUpdateEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnGoalUpdate(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnGoalUpdate(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_caption(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokCaptionEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnCaption(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnCaption(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_hourly_rank(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokHourlyRankEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnHourlyRank(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnHourlyRank(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_disconnected(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokDisconnectedEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnDisconnected(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnDisconnected(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_barrage(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokBarrageEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnBarrage(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnBarrage(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_sub_notify(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokSubNotifyEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnSubNotify(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnSubNotify(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_room_verify(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRoomVerifyEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRoomVerify(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRoomVerify(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_social(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokSocialEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnSocial(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnSocial(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_emote_chat(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokEmoteChatEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnEmoteChat(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnEmoteChat(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_poll(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokPollEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnPoll(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnPoll(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_room_pin(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRoomPinEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRoomPin(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRoomPin(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_room(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRoomEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRoom(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRoom(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_envelope(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokEnvelopeEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnEnvelope(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnEnvelope(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_websocket_unknown_message(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokWebsocketUnknownMessageEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokWebsocketUnknownMessageEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnWebsocketUnknownMessage(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnWebsocketUnknownMessage(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_connected(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokConnectedEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnConnected(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnConnected(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_im_delete(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokImDeleteEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnImDelete(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnImDelete(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_room_user_seq(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokRoomUserSeqEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnRoomUserSeq(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnRoomUserSeq(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_unauthorized_member(
         &mut self,
-        on_event: fn(
-            client: &TikTokLiveClient,
-            event_data: &TikTokUnauthorizedMemberEvent,
-        ),
+        on_event: fn(client: &TikTokLiveClient, event_data: &TikTokUnauthorizedMemberEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnUnauthorizedMember(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnUnauthorizedMember(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_oec_live_shopping(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokOecLiveShoppingEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnOecLiveShopping(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnOecLiveShopping(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLink(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLink(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
     pub fn on_link_mic_battle(
         &mut self,
         on_event: fn(client: &TikTokLiveClient, event_data: &TikTokLinkMicBattleEvent),
     ) -> &mut Self {
-        self.on_event(|client, incoming_event| {
-            match incoming_event {
-                TikTokLiveEvent::OnLinkMicBattle(event_instance) => {
-                    on_event(client, event_instance);
-                }
-                _ => {}
+        self.on_event(|client, incoming_event| match incoming_event {
+            TikTokLiveEvent::OnLinkMicBattle(event_instance) => {
+                on_event(client, event_instance);
             }
+            _ => {}
         })
     }
 }

--- a/src/generated/events_mapper.rs
+++ b/src/generated/events_mapper.rs
@@ -1,8 +1,8 @@
-use protobuf::Message;
 use crate::core::live_client::TikTokLiveClient;
-use crate::generated::messages::webcast::*;
 use crate::core::live_client_mapper::TikTokLiveMessageMapper;
 use crate::generated::events::*;
+use crate::generated::messages::webcast::*;
+use protobuf::Message;
 impl TikTokLiveMessageMapper {
     pub fn handle_single_message(
         &self,
@@ -13,330 +13,234 @@ impl TikTokLiveMessageMapper {
         let proto_message_content = &message.payload;
         match proto_message_name.as_str() {
             "WebcastLikeMessage" => {
-                let raw_data = WebcastLikeMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastLikeMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokLikeEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLike(event));
             }
             "WebcastQuestionNewMessage" => {
-                let raw_data = WebcastQuestionNewMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastQuestionNewMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokQuestionNewEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnQuestionNew(event));
             }
             "WebcastLinkMicBattlePunishFinish" => {
-                let raw_data = WebcastLinkMicBattlePunishFinish::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkMicBattlePunishFinishEvent {
-                    raw_data,
-                };
-                client
-                    .publish_event(TikTokLiveEvent::OnLinkMicBattlePunishFinish(event));
+                let raw_data =
+                    WebcastLinkMicBattlePunishFinish::parse_from_bytes(proto_message_content)
+                        .unwrap();
+                let event = TikTokLinkMicBattlePunishFinishEvent { raw_data };
+                client.publish_event(TikTokLiveEvent::OnLinkMicBattlePunishFinish(event));
             }
             "WebcastRankUpdateMessage" => {
-                let raw_data = WebcastRankUpdateMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastRankUpdateMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRankUpdateEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRankUpdate(event));
             }
             "WebcastLinkMicFanTicketMethod" => {
-                let raw_data = WebcastLinkMicFanTicketMethod::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkMicFanTicketMethodEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastLinkMicFanTicketMethod::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokLinkMicFanTicketMethodEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkMicFanTicketMethod(event));
             }
             "WebcastLiveIntroMessage" => {
-                let raw_data = WebcastLiveIntroMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastLiveIntroMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokLiveIntroEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLiveIntro(event));
             }
             "WebcastMemberMessage" => {
-                let raw_data = WebcastMemberMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastMemberMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokMemberEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnMember(event));
             }
             "WebcastChatMessage" => {
-                let raw_data = WebcastChatMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastChatMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokChatEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnChat(event));
             }
             "WebcastLinkMicArmies" => {
-                let raw_data = WebcastLinkMicArmies::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkMicArmiesEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastLinkMicArmies::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokLinkMicArmiesEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkMicArmies(event));
             }
             "WebcastLinkLayerMessage" => {
-                let raw_data = WebcastLinkLayerMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastLinkLayerMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokLinkLayerEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkLayer(event));
             }
             "WebcastResponse" => {
-                let raw_data = WebcastResponse::parse_from_bytes(proto_message_content)
-                    .unwrap();
+                let raw_data = WebcastResponse::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokResponseEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnResponse(event));
             }
             "WebcastPushFrame" => {
-                let raw_data = WebcastPushFrame::parse_from_bytes(proto_message_content)
-                    .unwrap();
+                let raw_data = WebcastPushFrame::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokPushFrameEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnPushFrame(event));
             }
             "WebcastRankTextMessage" => {
-                let raw_data = WebcastRankTextMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastRankTextMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRankTextEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRankText(event));
             }
             "WebcastSystemMessage" => {
-                let raw_data = WebcastSystemMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastSystemMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokSystemEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnSystem(event));
             }
             "WebcastLinkmicBattleTaskMessage" => {
-                let raw_data = WebcastLinkmicBattleTaskMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkmicBattleTaskEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastLinkmicBattleTaskMessage::parse_from_bytes(proto_message_content)
+                        .unwrap();
+                let event = TikTokLinkmicBattleTaskEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkmicBattleTask(event));
             }
             "WebcastGiftMessage" => {
-                let raw_data = WebcastGiftMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastGiftMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokGiftEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnGift(event));
             }
             "WebcastInRoomBannerMessage" => {
-                let raw_data = WebcastInRoomBannerMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokInRoomBannerEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastInRoomBannerMessage::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokInRoomBannerEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnInRoomBanner(event));
             }
             "WebcastMsgDetectMessage" => {
-                let raw_data = WebcastMsgDetectMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastMsgDetectMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokMsgDetectEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnMsgDetect(event));
             }
             "WebcastControlMessage" => {
-                let raw_data = WebcastControlMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastControlMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokControlEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnControl(event));
             }
             "WebcastLinkMicMethod" => {
-                let raw_data = WebcastLinkMicMethod::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkMicMethodEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastLinkMicMethod::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokLinkMicMethodEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkMicMethod(event));
             }
             "WebcastGoalUpdateMessage" => {
-                let raw_data = WebcastGoalUpdateMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastGoalUpdateMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokGoalUpdateEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnGoalUpdate(event));
             }
             "WebcastCaptionMessage" => {
-                let raw_data = WebcastCaptionMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastCaptionMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokCaptionEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnCaption(event));
             }
             "WebcastHourlyRankMessage" => {
-                let raw_data = WebcastHourlyRankMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastHourlyRankMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokHourlyRankEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnHourlyRank(event));
             }
             "WebcastBarrageMessage" => {
-                let raw_data = WebcastBarrageMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastBarrageMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokBarrageEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnBarrage(event));
             }
             "WebcastSubNotifyMessage" => {
-                let raw_data = WebcastSubNotifyMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastSubNotifyMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokSubNotifyEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnSubNotify(event));
             }
             "RoomVerifyMessage" => {
-                let raw_data = RoomVerifyMessage::parse_from_bytes(proto_message_content)
-                    .unwrap();
+                let raw_data = RoomVerifyMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRoomVerifyEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRoomVerify(event));
             }
             "WebcastSocialMessage" => {
-                let raw_data = WebcastSocialMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastSocialMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokSocialEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnSocial(event));
             }
             "WebcastEmoteChatMessage" => {
-                let raw_data = WebcastEmoteChatMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastEmoteChatMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokEmoteChatEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnEmoteChat(event));
             }
             "WebcastPollMessage" => {
-                let raw_data = WebcastPollMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastPollMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokPollEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnPoll(event));
             }
             "WebcastRoomPinMessage" => {
-                let raw_data = WebcastRoomPinMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastRoomPinMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRoomPinEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRoomPin(event));
             }
             "WebcastRoomMessage" => {
-                let raw_data = WebcastRoomMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastRoomMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRoomEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRoom(event));
             }
             "WebcastEnvelopeMessage" => {
-                let raw_data = WebcastEnvelopeMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastEnvelopeMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokEnvelopeEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnEnvelope(event));
             }
             "WebcastImDeleteMessage" => {
-                let raw_data = WebcastImDeleteMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastImDeleteMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokImDeleteEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnImDelete(event));
             }
             "WebcastRoomUserSeqMessage" => {
-                let raw_data = WebcastRoomUserSeqMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data =
+                    WebcastRoomUserSeqMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokRoomUserSeqEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnRoomUserSeq(event));
             }
             "WebcastUnauthorizedMemberMessage" => {
-                let raw_data = WebcastUnauthorizedMemberMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokUnauthorizedMemberEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastUnauthorizedMemberMessage::parse_from_bytes(proto_message_content)
+                        .unwrap();
+                let event = TikTokUnauthorizedMemberEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnUnauthorizedMember(event));
             }
             "WebcastOecLiveShoppingMessage" => {
-                let raw_data = WebcastOecLiveShoppingMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokOecLiveShoppingEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastOecLiveShoppingMessage::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokOecLiveShoppingEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnOecLiveShopping(event));
             }
             "WebcastLinkMessage" => {
-                let raw_data = WebcastLinkMessage::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
+                let raw_data = WebcastLinkMessage::parse_from_bytes(proto_message_content).unwrap();
                 let event = TikTokLinkEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLink(event));
             }
             "WebcastLinkMicBattle" => {
-                let raw_data = WebcastLinkMicBattle::parse_from_bytes(
-                        proto_message_content,
-                    )
-                    .unwrap();
-                let event = TikTokLinkMicBattleEvent {
-                    raw_data,
-                };
+                let raw_data =
+                    WebcastLinkMicBattle::parse_from_bytes(proto_message_content).unwrap();
+                let event = TikTokLinkMicBattleEvent { raw_data };
                 client.publish_event(TikTokLiveEvent::OnLinkMicBattle(event));
             }
             _ => {
-                client
-                    .publish_event(
-                        TikTokLiveEvent::OnWebsocketUnknownMessage(TikTokWebsocketUnknownMessageEvent {
-                            message_name: message.method.clone(),
-                            raw_data: message,
-                        }),
-                    );
+                client.publish_event(TikTokLiveEvent::OnWebsocketUnknownMessage(
+                    TikTokWebsocketUnknownMessageEvent {
+                        message_name: message.method.clone(),
+                        raw_data: message,
+                    },
+                ));
             }
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
 pub mod http_data;
 
-pub mod http_request_builder;
 pub mod http_data_mappers;
+pub mod http_request_builder;

--- a/src/http/http_data.rs
+++ b/src/http/http_data.rs
@@ -2,26 +2,22 @@ use std::time::Duration;
 
 use url::Url;
 
-pub struct LiveUserDataRequest
-{
+pub struct LiveUserDataRequest {
     pub user_name: String,
 }
 
-pub struct LiveUserDataResponse
-{
+pub struct LiveUserDataResponse {
     pub room_id: String,
     pub started_at_timestamp: i64,
     pub user_status: UserStatus,
     pub json: String,
 }
 
-pub struct LiveDataRequest
-{
+pub struct LiveDataRequest {
     pub room_id: String,
 }
 
-pub struct LiveDataResponse
-{
+pub struct LiveDataResponse {
     pub json: String,
     pub live_status: LiveStatus,
     pub title: String,
@@ -30,39 +26,30 @@ pub struct LiveDataResponse
     pub total_viewers: i64,
 }
 
-
-pub struct LiveConnectionDataRequest
-{
+pub struct LiveConnectionDataRequest {
     pub room_id: String,
 }
 
-pub struct LiveConnectionDataResponse
-{
+pub struct LiveConnectionDataResponse {
     pub web_socket_timeout: Duration,
     pub web_socket_cookies: String,
     pub web_socket_url: Url,
 }
 
-
-pub struct SignServerResponse
-{
+pub struct SignServerResponse {
     pub signed_url: String,
     pub user_agent: String,
 }
 
-
-pub enum UserStatus
-{
+pub enum UserStatus {
     NotFound,
     Offline,
     LivePaused,
     Live,
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
-pub enum LiveStatus
-{
+#[derive(Debug, PartialEq)]
+pub enum LiveStatus {
     HostNotFound,
     HostOnline,
     HostOffline,

--- a/src/http/http_data_mappers.rs
+++ b/src/http/http_data_mappers.rs
@@ -1,17 +1,14 @@
 use serde_json::Value;
 
-use crate::http::http_data::{LiveDataResponse, LiveUserDataResponse, SignServerResponse};
 use crate::http::http_data::LiveStatus::{HostNotFound, HostOffline, HostOnline};
 use crate::http::http_data::UserStatus::{Live, LivePaused, NotFound, Offline};
+use crate::http::http_data::{LiveDataResponse, LiveUserDataResponse, SignServerResponse};
 
-pub fn map_live_user_data_response(json: String) -> LiveUserDataResponse
-{
+pub fn map_live_user_data_response(json: String) -> LiveUserDataResponse {
     let json_value: Value = serde_json::from_str(json.as_str()).unwrap();
 
-
     let message = json_value["message"].as_str().unwrap();
-    if  message.eq("params_error")
-    {
+    if message.eq("params_error") {
         panic!("fetchRoomIdFromTiktokApi -> Unable to fetch roomID, contact the developer");
     }
     if message.eq("user_not_found") {
@@ -19,8 +16,7 @@ pub fn map_live_user_data_response(json: String) -> LiveUserDataResponse
     }
 
     let option_data = json_value["data"].as_object();
-    if option_data.is_none()
-    {
+    if option_data.is_none() {
         panic!("TikTokUserInfo.UserStatus.NotFound");
     }
     let option = option_data.unwrap();
@@ -38,17 +34,15 @@ pub fn map_live_user_data_response(json: String) -> LiveUserDataResponse
     let live_room = option["liveRoom"].as_object().unwrap();
     let start_time = live_room["startTime"].as_i64().unwrap();
 
-    return LiveUserDataResponse
-    {
+    LiveUserDataResponse {
         user_status,
         json: json.to_string(),
         room_id: room_id.to_string(),
         started_at_timestamp: start_time,
-    };
+    }
 }
 
-pub fn map_live_data_response(json: String) -> LiveDataResponse
-{
+pub fn map_live_data_response(json: String) -> LiveDataResponse {
     let json_value: Value = serde_json::from_str(json.as_str()).unwrap();
 
     let data = json_value["data"].as_object().unwrap();
@@ -66,25 +60,22 @@ pub fn map_live_data_response(json: String) -> LiveDataResponse
     let likes = stats["like_count"].as_i64().unwrap();
     let total_viewers = stats["total_user"].as_i64().unwrap();
 
-    return LiveDataResponse
-    {
+    LiveDataResponse {
         json,
         live_status,
         total_viewers,
         viewers,
         likes,
         title: title.to_string(),
-    };
+    }
 }
 
-pub fn map_sign_server_response(json: String) -> SignServerResponse
-{
+pub fn map_sign_server_response(json: String) -> SignServerResponse {
     let json_value: Value = serde_json::from_str(json.as_str()).unwrap();
     let signed_url = json_value["signedUrl"].as_str().unwrap();
     let user_agent = json_value["User-Agent"].as_str().unwrap();
 
-    return SignServerResponse
-    {
+    SignServerResponse {
         signed_url: signed_url.to_string(),
         user_agent: user_agent.to_string(),
     }

--- a/src/http/http_request_builder.rs
+++ b/src/http/http_request_builder.rs
@@ -7,141 +7,121 @@ use urlencoding::encode;
 
 use crate::data::live_common::{HttpData, TikTokLiveSettings};
 
-pub struct HttpRequestFactory
-{
+pub struct HttpRequestFactory {
     pub(crate) settings: TikTokLiveSettings,
 }
 
-impl HttpRequestFactory
-{
-    pub fn request(&self) -> HttpRequestBuilder
-    {
-        return HttpRequestBuilder
-        {
+impl HttpRequestFactory {
+    pub fn request(&self) -> HttpRequestBuilder {
+        HttpRequestBuilder {
             url: "".to_string(),
             http_data: self.settings.http_data.clone(),
-        };
+        }
     }
 }
 
-
-pub struct HttpRequestBuilder
-{
+pub struct HttpRequestBuilder {
     url: String,
     http_data: HttpData,
 }
 
-impl HttpRequestBuilder
-{
-    pub fn with_reset(&mut self) -> &mut Self
-    {
+impl HttpRequestBuilder {
+    pub fn with_reset(&mut self) -> &mut Self {
         self.http_data = HttpData::default();
         self
     }
 
-
-    pub fn with_time_out(&mut self, time_out: Duration) -> &mut Self
-    {
+    pub fn with_time_out(&mut self, time_out: Duration) -> &mut Self {
         self.http_data.time_out = time_out;
         self
     }
-    pub fn with_url(&mut self, url: &str) -> &mut Self
-    {
+    pub fn with_url(&mut self, url: &str) -> &mut Self {
         self.url = url.to_string();
         self
     }
 
-    pub fn with_param(&mut self, name: &str, value: &str) -> &mut Self
-    {
-        self.http_data.params.insert(name.to_string(), value.to_string());
+    pub fn with_param(&mut self, name: &str, value: &str) -> &mut Self {
+        self.http_data
+            .params
+            .insert(name.to_string(), value.to_string());
         self
     }
 
-    pub fn with_params(&mut self, params: &HashMap<String, String>) -> &mut Self
-    {
-        for entry in params
-        {
+    pub fn with_params(&mut self, params: &HashMap<String, String>) -> &mut Self {
+        for entry in params {
             self.with_param(entry.0, entry.1);
         }
 
         self
     }
 
-
-    pub fn with_header(&mut self, name: &str, value: &str) -> &mut Self
-    {
-        self.http_data.headers.insert(name.to_string(), value.to_string());
+    pub fn with_header(&mut self, name: &str, value: &str) -> &mut Self {
+        self.http_data
+            .headers
+            .insert(name.to_string(), value.to_string());
         self
     }
 
-
-    pub fn with_cookie(&mut self, name: &str, value: &str) -> &mut Self
-    {
-        self.http_data.cookies.insert(name.to_string(), value.to_string());
+    pub fn with_cookie(&mut self, name: &str, value: &str) -> &mut Self {
+        self.http_data
+            .cookies
+            .insert(name.to_string(), value.to_string());
         self
     }
 
-    pub fn build_client(&mut self) -> Client
-    {
+    pub fn build_client(&mut self) -> Client {
         let client = Client::builder()
             .timeout(self.http_data.time_out)
-            .build().unwrap();
+            .build()
+            .unwrap();
 
-
-        return client;
+        client
     }
-    pub fn build_get_request(&mut self) -> RequestBuilder
-    {
+    pub fn build_get_request(&mut self) -> RequestBuilder {
         let client = self.build_client();
         let url = self.as_url();
         let mut res = client.get(url);
-        for header in self.http_data.headers.clone()
-        {
+        for header in self.http_data.headers.clone() {
             res = res.header(header.0, header.1);
         }
-        return res;
+        res
     }
 
-    pub async fn as_json(&mut self) -> Option<String>
-    {
-        let result = self.build_get_request().send()
-            .await.unwrap();
+    pub async fn as_json(&mut self) -> Option<String> {
+        let result = self.build_get_request().send().await.unwrap();
 
-        if result.status().is_success()
-        {
+        if result.status().is_success() {
             let json_res = result.text().await.unwrap();
-            return Some(json_res);
+            Some(json_res)
         } else {
-            return None;
+            None
         }
     }
 
-    pub async fn as_bytes(&mut self) -> Option<Bytes>
-    {
-        let result = self.build_get_request().send()
-            .await.unwrap();
+    pub async fn as_bytes(&mut self) -> Option<Bytes> {
+        let result = self.build_get_request().send().await.unwrap();
 
-        if result.status().is_success()
-        {
+        if result.status().is_success() {
             let bytes = result.bytes().await.unwrap();
-            return Some(bytes);
+            Some(bytes)
         } else {
-            return None;
+            None
         }
     }
 
-    pub fn as_url(&mut self) -> String
-    {
-        if self.http_data.params.len() == 0
-        {
+    pub fn as_url(&mut self) -> String {
+        if self.http_data.params.len() == 0 {
             return self.url.to_string();
         }
 
-        let query = self.http_data.params.iter()
+        let query = self
+            .http_data
+            .params
+            .iter()
             .map(|(key, value)| format!("{}={}", key, encode(value)))
             .collect::<Vec<_>>()
             .join("&");
         let url = format!("{}?{}", self.url, query);
-        return url;
+        url
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use crate::core::live_client_builder::TikTokLiveBuilder;
-use crate::core::live_client_http::TikTokLiveHttpClient;
 
 ///  # Data structures
 pub mod data;
@@ -12,8 +11,6 @@ pub mod http;
 
 ///  # ProtocolBuffer structures
 pub mod generated;
-
-
 
 ///
 /// # Entry point of library used to create new instance of TikTokLive client
@@ -30,15 +27,11 @@ pub mod generated;
 ///
 pub struct TikTokLive {}
 
-impl TikTokLive
-{
+impl TikTokLive {
     ///
     /// Returns builder for creating new TikTokLiveClient
     ///
-    pub fn new_client(user_name: &str) -> TikTokLiveBuilder
-    {
+    pub fn new_client(user_name: &str) -> TikTokLiveBuilder {
         TikTokLiveBuilder::new(user_name)
     }
-
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,16 @@
-use std::{io, thread};
+use std::io;
 use std::time::Duration;
 
 use tiktoklive::core::live_client::TikTokLiveClient;
 use tiktoklive::data::live_common::TikTokLiveSettings;
-use tiktoklive::generated::events::{TikTokLiveEvent};
+use tiktoklive::generated::events::TikTokLiveEvent;
 
 use tiktoklive::TikTokLive;
 
 #[tokio::main]
 async fn main() {
     let user_name = "dash4214";
-    let mut client = TikTokLive::new_client(user_name)
+    let client = TikTokLive::new_client(user_name)
         .configure(configure)
         .on_event(handle_event)
         .build();
@@ -18,36 +18,36 @@ async fn main() {
     client.connect().await;
 
     let mut input = String::new();
-    if io::stdin().read_line(&mut input).is_ok() && input.trim() == "stop"
-    {
+    if io::stdin().read_line(&mut input).is_ok() && input.trim() == "stop" {
         //client.disconnect();
     }
 }
 
-fn handle_event(client: &TikTokLiveClient, event: &TikTokLiveEvent)
-{
+fn handle_event(_client: &TikTokLiveClient, event: &TikTokLiveEvent) {
     match event {
-        TikTokLiveEvent::OnMember(joinEvent) =>
-            {
-                println!("user: {}  joined", joinEvent.raw_data.user.nickname);
-            }
-        TikTokLiveEvent::OnChat(chatEvent) =>
-            {
-                println!("user: {} -> {} ", chatEvent.raw_data.user.nickname, chatEvent.raw_data.content);
-            }
-        TikTokLiveEvent::OnGift(giftEvent) =>
-            {
-                let nick = &giftEvent.raw_data.user.nickname;
-                let gift_name = &giftEvent.raw_data.gift.name;
-                let gifts_amount = giftEvent.raw_data.gift.combo;
+        TikTokLiveEvent::OnMember(join_event) => {
+            println!("user: {}  joined", join_event.raw_data.user.nickname);
+        }
+        TikTokLiveEvent::OnChat(chat_event) => {
+            println!(
+                "user: {} -> {} ",
+                chat_event.raw_data.user.nickname, chat_event.raw_data.content
+            );
+        }
+        TikTokLiveEvent::OnGift(gift_event) => {
+            let nick = &gift_event.raw_data.user.nickname;
+            let gift_name = &gift_event.raw_data.gift.name;
+            let gifts_amount = gift_event.raw_data.gift.combo;
 
-                println!("user: {} sends gift: {} x {}", nick, gift_name, gifts_amount);
-            }
+            println!(
+                "user: {} sends gift: {} x {}",
+                nick, gift_name, gifts_amount
+            );
+        }
         _ => {}
     }
 }
 
-fn configure(settings: &mut TikTokLiveSettings)
-{
+fn configure(settings: &mut TikTokLiveSettings) {
     settings.http_data.time_out = Duration::from_secs(12);
 }


### PR DESCRIPTION
 • Applied  rustfmt  for consistent formatting.
 • Removed unused imports.
 • Corrected naming conventions to follow Rust's snake_case.
 • Simplified control flow by removing unnecessary  else  blocks.

 This PR enhances code readability and adheres to Rust idiomatic standards.